### PR TITLE
Adding replies workaround

### DIFF
--- a/listeners/messageCreateHandlers/tulpaHandler.js
+++ b/listeners/messageCreateHandlers/tulpaHandler.js
@@ -97,7 +97,7 @@ module.exports = function (bot) {
 
 		// If there's an attachment, handle that separately
 		if (msg.attachments[0]) {
-			if (msg.attachments.reduce((sum, cur) => sum + cur.size) < 8000000) {
+			if (msg.attachments.reduce((sum, cur) => sum + cur.size, 0) < 8000000) {
 				tulpa.posts++;
 				return bot.webhooks.sendAttachment(msg, cfg, data, content, hook);
 			}

--- a/listeners/messageCreateHandlers/tulpaHandler.js
+++ b/listeners/messageCreateHandlers/tulpaHandler.js
@@ -1,5 +1,3 @@
-const { Channel, TextChannel } = require("eris");
-
 module.exports = function (bot) {
 	const aniRegex = /^<a:[^\s:]+:\d+>$/mi;
 	const priorities = bot.priorities;

--- a/listeners/messageCreateHandlers/tulpaHandler.js
+++ b/listeners/messageCreateHandlers/tulpaHandler.js
@@ -83,7 +83,8 @@ module.exports = function (bot) {
 		const messageParts = [originalMsg.substring(0, length).trim()];
 		const spoilerMdRegex = /\|\|/g;
 
-		// Check for spoiler tags that might have gotten truncated and add ones to the end if needed
+		// Check for spoiler tags that might have gotten truncated 
+		// and add extra ones to the end if needed
 		if ((messageParts[0].match(spoilerMdRegex) || []).length % 2 !== 0 &&
 				(originalMsg.match(spoilerMdRegex) || []).length % 2 === 0) {
 			messageParts.push('||');
@@ -94,7 +95,9 @@ module.exports = function (bot) {
 	}
 
 	function formatReplyEmbed (reply, maxLen = 75) {
-		const message = reply.content.length <= maxLen ? reply.content.trim() : truncateMessage(reply.content, maxLen)
+		const message = reply.content.length <= maxLen ? 
+			reply.content.trim() : 
+			truncateMessage(reply.content, maxLen)
 		const description = [
 			'[Reply to:',
 			reply.attachments.length > 0 && ' :paperclip:',
@@ -105,7 +108,9 @@ module.exports = function (bot) {
 		return {
 			type: "rich",
 			author: {
-				name: reply.member && reply.member.nick ? reply.member.nick : reply.author.username,
+				name: (reply.member && reply.member.nick) ? 
+					reply.member.nick : 
+					reply.author.username,
 				icon_url: reply.author.avatarURL,
 			},
 			description: description,

--- a/listeners/messageCreateHandlers/tulpaHandler.js
+++ b/listeners/messageCreateHandlers/tulpaHandler.js
@@ -111,7 +111,7 @@ module.exports = function (bot) {
 				name: (reply.member && reply.member.nick) ? 
 					reply.member.nick : 
 					reply.author.username,
-				icon_url: reply.author.avatarURL,
+				icon_url: reply.author.staticAvatarURL,
 			},
 			description: description,
 		};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "tupperware bot for discord tulpa hooks",
   "main": "bot.js",
   "scripts": {
+    "start": "node bot",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Keter",


### PR DESCRIPTION
This adds a workaround since replies are not available in webhooks.
This is inspired by PK's implementation and a couple additional edge cases were identified there.

Adds a new variable to the config: `maxReplyLength` that shouldn't be required, but is supported. The default fallback, 75, seemed to be approx the max size that could fit on one line at the max embed size

So far seems to handle everything thrown at it, see screenshot:

![image](https://user-images.githubusercontent.com/78641371/107115795-ee888300-6823-11eb-86b7-3e7252a47531.png)

This also fixed attachments not being proxied through the webhook as the reduce function was just returning an object and not the computed size without the initial value.

I also added `npm start` as a script to start the bot since some tooling can read the script files and it's the common way to start apps
